### PR TITLE
Epita X France image

### DIFF
--- a/overlay.json
+++ b/overlay.json
@@ -4,7 +4,7 @@
     {
       "name": "Drapeau de Gauche",
       "sources": [
-        "https://i.imgur.com/IYwCC4H.png"
+        "https://i.imgur.com/BEjngee.png"
       ],
       "x": 0,
       "y": 130


### PR DESCRIPTION
Cette PR a pour but d'ajouter le logo EPITA sur le drapeau français de gauche.

Epita est une école d'informatique française ! 

@Sayrix 