### PR TITLE
Epita x france

### DIFF
--- a/overlay.json
+++ b/overlay.json
@@ -20,7 +20,7 @@
     {
       "name": "Drapeau de droite",
       "sources": [
-        "https://i.imgur.com/gwtlXkp.png"
+        "https://i.imgur.com/u89DhbU.png"
       ],
       "x": 1887,
       "y": 130

--- a/overlay.json
+++ b/overlay.json
@@ -20,7 +20,7 @@
     {
       "name": "Drapeau de droite",
       "sources": [
-        "https://i.imgur.com/7a87lVe.png"
+        "https://i.imgur.com/gwtlXkp.png"
       ],
       "x": 1887,
       "y": 130

--- a/overlay.json
+++ b/overlay.json
@@ -4,7 +4,7 @@
     {
       "name": "Drapeau de Gauche",
       "sources": [
-        "https://i.imgur.com/BEjngee.png"
+        "https://i.imgur.com/Sj1D66s.png"
       ],
       "x": 0,
       "y": 130

--- a/overlay.json
+++ b/overlay.json
@@ -4,7 +4,7 @@
     {
       "name": "Drapeau de Gauche",
       "sources": [
-        "https://i.imgur.com/qfhaB5b.png"
+        "https://i.imgur.com/5e69jFT.png"
       ],
       "x": 0,
       "y": 130


### PR DESCRIPTION
Cette PR a pour but de déplacer le logo EPITA sur le drapeau français du milieu vu l'espace libre (il était sur celui de gauche, a l'endroit de la guerre).

Epita est une école d'informatique française !

@Sayrix 
